### PR TITLE
Fix dox trying to push markdown files in vendor folder for go based p…

### DIFF
--- a/internal/find.go
+++ b/internal/find.go
@@ -23,6 +23,10 @@ func walk(path string, info os.FileInfo, err error) error {
 		return filepath.SkipDir
 	}
 
+	if name == "vendor" {
+		return filepath.SkipDir
+	}
+
 	if info.IsDir() {
 		return nil
 	}


### PR DESCRIPTION
…rojects.

This fix skips over the vendor folder which can be found in go based projects with vendoring enabled.